### PR TITLE
fix(backend): Add CORS middleware to allow frontend requests

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^6.13.0",
         "bcryptjs": "^3.0.2",
+        "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -18,6 +19,7 @@
       },
       "devDependencies": {
         "@types/bcryptjs": "^3.0.0",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.1.0",
@@ -220,6 +222,15 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -652,6 +663,18 @@
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-require": {
@@ -1433,6 +1456,14 @@
       },
       "engines": {
         "node": "^14.16.0 || >=16.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@prisma/client": "^6.13.0",
     "bcryptjs": "^3.0.2",
+    "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@types/bcryptjs": "^3.0.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.1.0",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,11 +1,21 @@
-import express, { Request, Response } from "express";
+import express from "express";
 import dotenv from "dotenv";
+import cors from "cors";
+
+
 import userRoutes from "./routes/userRoutes";
 
 dotenv.config();
 
 const app = express();
 const port = process.env.PORT || 5000;
+
+// CORS configuration to allow requests from the frontend
+app.use(
+  cors({
+    origin: "http://localhost:3000",
+  })
+);
 
 app.use(express.json()); // Enabale Express to parse JSON bodies
 


### PR DESCRIPTION
This pull request resolves a CORS (Cross-Origin Resource Sharing) policy error that was blocking requests from the Next.js frontend (http://localhost:3000) to the Node.js backend (http://localhost:5000).

The cors middleware has been configured on the Express server to explicitly allow requests from the frontend's origin. This is a crucial fix that enables the frontend to communicate with the backend for features like user registration and login.

### Key Changes:
-  Middleware Installation: The cors package and its types have been installed.
-  CORS Configuration: The cors middleware is now initialized in server.ts with origin: 'http://localhost:3000', allowing cross-origin requests from our frontend.

###  How to Test:
- Make sure both the backend and frontend development servers are running.
- Navigate to the login or register pages on the frontend (http://localhost:3000/login or /register).
- Attempt to register a new user or log in with an existing user.
- Verify that the registration/login is successful and that there are no CORS-related errors in the browser's console.