### PR TITLE
feat(frontend): Fetch and display project list from backend

### DIFF
--- a/frontend/src/app/projects/page.tsx
+++ b/frontend/src/app/projects/page.tsx
@@ -1,22 +1,62 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { getProjects } from '../../lib/api';
+
+interface Project {
+  id: number;
+  name: string;
+  description: string;
+  goal: number;
+  raised: number;
+}
+
 export default function Projects() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchProjects = async () => {
+      try {
+        const data = await getProjects();
+        setProjects(data);
+        setLoading(false);
+      } catch (error) {
+        console.error('Failed to fetch projects:', error);
+        setLoading(false);
+      }
+    };
+
+    fetchProjects();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p>Loading projects...</p>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-gray-100 min-h-screen p-8">
       <div className="container mx-auto bg-white p-8 rounded-lg shadow-md">
-        <h1 className="text-3xl font-bold mb-4">Our Projects</h1>
-        <ul className="list-disc list-inside text-gray-700">
-          <li>
-            Education for All: Providing school supplies and scholarships to
-            children in need.
-          </li>
-          <li>
-            Clean Water Initiative: Building wells and providing water purifiers
-            to rural communities.
-          </li>
-          <li>
-            Health and Wellness: Offering free medical check-ups and health
-            education workshops.
-          </li>
-        </ul>
+        <h1 className="text-3xl font-bold mb-6">Our Projects</h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {projects.length > 0 ? (
+            projects.map(project => (
+              <div key={project.id} className="bg-blue-50 p-6 rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300">
+                <h2 className="text-xl font-semibold mb-2">{project.name}</h2>
+                <p className="text-gray-700 mb-4">{project.description}</p>
+                <div className="text-sm text-gray-500">
+                  <p>Goal: ${project.goal.toLocaleString()}</p>
+                  <p>Raised: ${project.raised.toLocaleString()}</p>
+                </div>
+              </div>
+            ))
+          ) : (
+            <p className="text-gray-500">No projects found.</p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,3 +24,8 @@ export const getProfile = async (token: string) => {
   });
   return response.data;
 };
+
+export const getProjects = async () => {
+  const response = await axios.get(`${API_URL}/projects`);
+  return response.data;
+}


### PR DESCRIPTION
This pull request builds the first dynamic public-facing page on the frontend by connecting it to the backend's project management API. The static Projects page is refactored to fetch a list of all charity projects and display them in a user-friendly, responsive grid.

This feature is a key step in bringing the frontend and backend together and demonstrates how to consume a public API endpoint.

### Key Changes:
- API Service Update: A new getProjects function is added to lib/api.ts to make an API call to GET /api/projects.
- Dynamic Projects Page (app/projects/page.tsx):
  - The page is converted into a client component to handle state and lifecycle hooks.
  - It uses useState and useEffect to fetch project data when the component loads.
  - A loading indicator is displayed while the data is being fetched.
  - Project data is rendered in a responsive grid, showcasing the name, description, goal, and raised amount for each project.
  - Appropriate handling for an empty list of projects is included.

### How to Test:
- Ensure both your backend (npm run dev in the backend directory) and frontend (npm run dev in the root) development servers are running.
- Navigate to http://localhost:3000/projects.
  - No Projects: If your database has no projects, the page should display a "Loading..." message followed by "No projects found."
  - With Projects: If you have created projects using the backend API (via Postman, for example), the page should display a list of all projects in a grid format with their details.
- Check the browser console to confirm there are no network errors when fetching the data.