### PR TITLE
feat(frontend): Add donation modal with API integration

### DIFF
--- a/frontend/src/app/projects/page.tsx
+++ b/frontend/src/app/projects/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { useState, useEffect } from "react";
 import { getProjects } from "../../lib/api";
-import { useAuth } from "@/context/AuthContext";
+import { useAuth } from "../../context/AuthContext";
+import DonationModal from "@/components/DonationsModal";
 
 interface Project {
   id: number;
@@ -15,21 +16,33 @@ export default function Projects() {
   const { user } = useAuth();
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+
+  const fetchProjects = async () => {
+    try {
+      const data = await getProjects();
+      setProjects(data);
+      setLoading(false);
+    } catch (error) {
+      console.error("Failed to fetch projects:", error);
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const fetchProjects = async () => {
-      try {
-        const data = await getProjects();
-        setProjects(data);
-        setLoading(false);
-      } catch (error) {
-        console.error("Failed to fetch projects:", error);
-        setLoading(false);
-      }
-    };
-
     fetchProjects();
   }, []);
+
+  const handleDonateClick = (project: Project) => {
+    setSelectedProject(project);
+    setIsModalOpen(true);
+  };
+
+  const handleDonationSuccess = () => {
+    // Refresh the projects list to show the updated "raised" amount
+    fetchProjects();
+  };
 
   if (loading) {
     return (
@@ -58,7 +71,7 @@ export default function Projects() {
                 </div>
                 {user && (
                   <button
-                    onClick={() => alert(`Donate to project: ${project.name}`)}
+                    onClick={() => handleDonateClick(project)}
                     className="mt-4 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700"
                   >
                     Donate
@@ -71,6 +84,14 @@ export default function Projects() {
           )}
         </div>
       </div>
+      {isModalOpen && selectedProject && (
+        <DonationModal
+          projectId={selectedProject.id}
+          projectName={selectedProject.name}
+          onClose={() => setIsModalOpen(false)}
+          onDonationSuccess={handleDonationSuccess}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/DonationsModal.tsx
+++ b/frontend/src/components/DonationsModal.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { useAuth } from "../context/AuthContext";
+import { createDonation } from "../lib/api";
+
+interface DonationModalProps {
+  projectId: number;
+  projectName: string;
+  onClose: () => void;
+  onDonationSuccess: () => void;
+}
+
+export default function DonationModal({
+  projectId,
+  projectName,
+  onClose,
+  onDonationSuccess,
+}: DonationModalProps) {
+  const { user } = useAuth();
+  const [amount, setAmount] = useState(0);
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user || amount <= 0) return;
+
+    setLoading(true);
+    try {
+      const token = localStorage.getItem("token");
+      if (token) {
+        await createDonation({ projectId, amount, message }, token);
+        onDonationSuccess();
+        onClose();
+      }
+    } catch (error) {
+      console.error("Failed to create donation:", error);
+      alert("Failed to process donation. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full flex items-center justify-center">
+      <div className="bg-white p-8 rounded-lg shadow-xl w-1/3">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-2xl font-bold">Donate to {projectName}</h3>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-800 text-3xl"
+          >
+            &times;
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-gray-700">Amount ($)</label>
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(Number(e.target.value))}
+              className="w-full px-3 py-2 border rounded-md"
+              min="1"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-gray-700">Message (optional)</label>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              className="w-full px-3 py-2 border rounded-md"
+              rows={3}
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full px-4 py-2 text-white bg-green-600 rounded-lg hover:bg-green-700 disabled:bg-green-300"
+            disabled={loading}
+          >
+            {loading ? "Processing..." : `Donate $${amount}`}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,3 @@
-// tailwind.config.ts
 import type { Config } from "tailwindcss";
 
 const config: Config = {


### PR DESCRIPTION
This pull request completes the frontend donation feature by implementing a functional donation modal and integrating it with the backend donation API. This enhancement replaces the previous placeholder button with a seamless, user-friendly donation flow.

This is the second of two commits for the feature/frontend-donations branch. The first commit created the "My Donations" page, and this one completes the donation process from the public projects page.

### Key Changes:
- New DonationModal Component: A reusable modal component is created to handle the donation form.
- API Integration: The modal component uses the createDonation API function to securely submit donation data to the backend.
- UI Update: Upon a successful donation, the Projects page automatically re-fetches the project data to display the updated raised amount, ensuring the UI is always in sync with the database.
- State Management: The Projects page now manages the state of the modal, including whether it is open and which project is selected for donation.

### How to Test: Ensure both your backend and frontend servers are running.
1. Log in as a user on the frontend.
2. Initiate a Donation: Go to the /projects page and click the "Donate" button on any project.
3. Complete the Donation: Fill in the amount and an optional message in the modal and click "Donate".
4. Verify the UI Update: After a successful donation, the modal should close, and the raised amount on the project card should instantly update.
5. Check Donation History: Navigate to the "My Donations" page to confirm the new donation appears in the list.